### PR TITLE
Add ros2 run

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Zsh:
 
 # Usage
 
+## Executable
+
+| Command | Alias |
+| --- | --- |
+| `ros2 run` | `rrun` |
+
 ## Topics
 
 | Command | Alias |

--- a/ros2_utils.bash
+++ b/ros2_utils.bash
@@ -5,19 +5,15 @@
 function rrun {
   if [ $# -eq 0 ]; then
     PKG_NAME=$(ros2 pkg list | fzf)
-    if [ -z $PKG_NAME ]; then
-      return
-    fi
+    [[ -z "$PKG_NAME" ]] && return
+    history -s "rrun $PKG_NAME"
     rrun $PKG_NAME
   elif [ $# -eq 1 ]; then
     PKG_AND_EXE=$(ros2 pkg executables | grep $1 | fzf)
-    if [ -z "$PKG_AND_EXE" ]; then
-      return
-    fi
+    [[ -z "$PKG_AND_EXE" ]] && return
     CMD="ros2 run $PKG_AND_EXE"
     echo "$CMD"
     $CMD
-    history -s "rrun $1"
     history -s $CMD
   fi
 }

--- a/ros2_utils.bash
+++ b/ros2_utils.bash
@@ -2,11 +2,11 @@
 
 # ROS 2 run
 
-function rnrun {
+function rrun {
   if [ $# -eq 0 ]; then
     PKG_NAME=$(ros2 pkg list | fzf)
     [[ -z "$PKG_NAME" ]] && return
-    history -s "rnrun $PKG_NAME"
+    history -s "rrun $PKG_NAME"
     rrun $PKG_NAME
   elif [ $# -eq 1 ]; then
     PKG_AND_EXE=$(ros2 pkg executables | grep $1 | fzf)
@@ -14,7 +14,7 @@ function rnrun {
     CMD="ros2 run $PKG_AND_EXE"
     echo "$CMD"
     $CMD
-    history -s rnrun
+    history -s rrun
     history -s $CMD
   fi
 }

--- a/ros2_utils.bash
+++ b/ros2_utils.bash
@@ -14,6 +14,7 @@ function rrun {
     CMD="ros2 run $PKG_AND_EXE"
     echo "$CMD"
     $CMD
+    history -s rnrun
     history -s $CMD
   fi
 }

--- a/ros2_utils.bash
+++ b/ros2_utils.bash
@@ -1,5 +1,27 @@
 #!/usr/bin/env bash
 
+# ROS 2 run
+
+function rrun {
+  if [ $# -eq 0 ]; then
+    PKG_NAME=$(ros2 pkg list | fzf)
+    if [ -z $PKG_NAME ]; then
+      return
+    fi
+    rrun $PKG_NAME
+  elif [ $# -eq 1 ]; then
+    PKG_AND_EXE=$(ros2 pkg executables | grep $1 | fzf)
+    if [ -z "$PKG_AND_EXE" ]; then
+      return
+    fi
+    CMD="ros2 run $PKG_AND_EXE"
+    echo "$CMD"
+    $CMD
+    history -s "rrun $1"
+    history -s $CMD
+  fi
+}
+
 # Topics
 
 function rtlist {

--- a/ros2_utils.bash
+++ b/ros2_utils.bash
@@ -2,11 +2,11 @@
 
 # ROS 2 run
 
-function rrun {
+function rnrun {
   if [ $# -eq 0 ]; then
     PKG_NAME=$(ros2 pkg list | fzf)
     [[ -z "$PKG_NAME" ]] && return
-    history -s "rrun $PKG_NAME"
+    history -s "rnrun $PKG_NAME"
     rrun $PKG_NAME
   elif [ $# -eq 1 ]; then
     PKG_AND_EXE=$(ros2 pkg executables | grep $1 | fzf)

--- a/ros2_utils.zsh
+++ b/ros2_utils.zsh
@@ -2,11 +2,11 @@
 
 # ROS 2 run
 
-function rnrun {
+function rrun {
   if [ $# -eq 0 ]; then
     PKG_NAME=$(ros2 pkg list | fzf)
     [[ -z "$PKG_NAME" ]] && return
-    print -s rnrun $PKG_NAME
+    print -s rrun $PKG_NAME
     rrun $PKG_NAME
   elif [ $# -eq 1 ]; then
     PKG_AND_EXE=$(ros2 pkg executables | grep $1 | fzf)
@@ -14,7 +14,7 @@ function rnrun {
     CMD=(ros2 run $PKG_AND_EXE)
     echo $CMD
     eval $CMD
-    print -s rnrun
+    print -s rrun
     print -s $CMD
   fi
 }

--- a/ros2_utils.zsh
+++ b/ros2_utils.zsh
@@ -1,5 +1,27 @@
 #!/usr/bin/env zsh
 
+# ROS 2 run
+
+function rrun {
+  if [ $# -eq 0 ]; then
+    PKG_NAME=$(ros2 pkg list | fzf)
+    if [ -z $PKG_NAME ]; then
+      return
+    fi
+    rrun $PKG_NAME
+  elif [ $# -eq 1 ]; then
+    PKG_AND_EXE=$(ros2 pkg executables | grep $1 | fzf)
+    if [ -z $PKG_AND_EXE ]; then
+      return
+    fi
+    CMD=(ros2 run $PKG_AND_EXE)
+    echo $CMD
+    eval $CMD
+    print -s rrun $1
+    print -s $CMD
+  fi
+}
+
 # Topics
 
 function rtlist {

--- a/ros2_utils.zsh
+++ b/ros2_utils.zsh
@@ -2,11 +2,11 @@
 
 # ROS 2 run
 
-function rrun {
+function rnrun {
   if [ $# -eq 0 ]; then
     PKG_NAME=$(ros2 pkg list | fzf)
     [[ -z "$PKG_NAME" ]] && return
-    print -s rrun $PKG_NAME
+    print -s rnrun $PKG_NAME
     rrun $PKG_NAME
   elif [ $# -eq 1 ]; then
     PKG_AND_EXE=$(ros2 pkg executables | grep $1 | fzf)
@@ -14,6 +14,7 @@ function rrun {
     CMD=(ros2 run $PKG_AND_EXE)
     echo $CMD
     eval $CMD
+    print -s rnrun
     print -s $CMD
   fi
 }

--- a/ros2_utils.zsh
+++ b/ros2_utils.zsh
@@ -5,19 +5,15 @@
 function rrun {
   if [ $# -eq 0 ]; then
     PKG_NAME=$(ros2 pkg list | fzf)
-    if [ -z $PKG_NAME ]; then
-      return
-    fi
+    [[ -z "$PKG_NAME" ]] && return
+    print -s rrun $PKG_NAME
     rrun $PKG_NAME
   elif [ $# -eq 1 ]; then
     PKG_AND_EXE=$(ros2 pkg executables | grep $1 | fzf)
-    if [ -z $PKG_AND_EXE ]; then
-      return
-    fi
+    [[ -z "$PKG_AND_EXE" ]] && return
     CMD=(ros2 run $PKG_AND_EXE)
     echo $CMD
     eval $CMD
-    print -s rrun $1
     print -s $CMD
   fi
 }


### PR DESCRIPTION
`ros2 run` has been implemented.
`fzf` searches for `package_name` and `executable_name`, respectively.
I was wondering whether to define the alias name as `rrun` or `rosrun`.
@tonynajjar can choose another one. I want to follow your policy. 